### PR TITLE
#17: define JPMS descriptor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/**
 .idea/**
 *.iml
 
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     </distributionManagement>
  
     <properties>
-        <jdkVersion>1.7</jdkVersion>
+        <jdkVersion>7</jdkVersion>
         <legal.doc.source>${maven.multiModuleProjectDirectory}</legal.doc.source>
     </properties>
 
@@ -74,8 +74,24 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.1.1</version>
+                    <configuration>
+                        <release>${jdkVersion}</release>
+                        <sourceFileExcludes>
+                            <sourceFileExclude>module-info.java</sourceFileExclude>
+                        </sourceFileExcludes>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>3.0.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -84,17 +100,33 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>${jdkVersion}</source>
-                    <target>${jdkVersion}</target>
+                    <release>9</release>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                    </compilerArgs>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>base-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>${jdkVersion}</release>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>4.2.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -120,13 +152,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.1.2</version>
                 <configuration>
                     <archive>  
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                        <manifestEntries>
-                            <Built-By>Oracle</Built-By>
-                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>
@@ -160,7 +189,7 @@
             <!-- prevent the site plugin from deploying to the scm url -->
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.8.2</version>
                 <executions>
                     <execution>
                         <id>stage-for-scm-publish</id>
@@ -188,12 +217,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8.1</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -213,19 +237,18 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.0.0</version>
                 <reportSets>
                     <reportSet>
                         <id>aggregate-project-info</id>
                         <inherited>false</inherited>
                         <reports>
                             <report>index</report>
-                            <report>license</report>
-                            <report>issue-tracking</report>
+                            <report>licenses</report>
+                            <report>issue-management</report>
                             <report>dependency-info</report>
                             <report>scm</report>
                             <report>distribution-management</report>
-                            <report>project-team</report>
+                            <report>team</report>
                             <report>summary</report>
                         </reports>
                     </reportSet>
@@ -235,7 +258,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
                 <reportSets>
                     <reportSet>
                         <id>javadoc-only</id>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,8 @@
     </distributionManagement>
  
     <properties>
-        <jdkVersion>7</jdkVersion>
+        <base.jdk.version>8</base.jdk.version>
+        <upper.jdk.version>9</upper.jdk.version>
         <legal.doc.source>${maven.multiModuleProjectDirectory}</legal.doc.source>
     </properties>
 
@@ -82,7 +83,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.1.1</version>
                     <configuration>
-                        <release>${jdkVersion}</release>
+                        <release>${base.jdk.version}</release>
                         <sourceFileExcludes>
                             <sourceFileExclude>module-info.java</sourceFileExclude>
                         </sourceFileExcludes>
@@ -102,7 +103,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>9</release>
+                    <release>${upper.jdk.version}</release>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                     </compilerArgs>
@@ -114,7 +115,7 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-                            <release>${jdkVersion}</release>
+                            <release>${base.jdk.version}</release>
                             <excludes>
                                 <exclude>module-info.java</exclude>
                             </excludes>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+module org.glassfish.external.management.api {
+
+    requires java.logging;
+    requires transitive java.management;
+
+    exports org.glassfish.external.amx;
+    exports org.glassfish.external.arc;
+    exports org.glassfish.external.probe.provider;
+    exports org.glassfish.external.probe.provider.annotations;
+    exports org.glassfish.external.statistics;
+    exports org.glassfish.external.statistics.annotations;
+    exports org.glassfish.external.statistics.impl;
+}


### PR DESCRIPTION
Fixes #17 , defines module name to `org.glassfish.external.management.api`. After this change, JDK used to build the project needs to be switched to 9+ (I tested this on Java SE 11). Produced binary is still `1.7` except of module-info, which is at binary level `9`. 

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>