### PR TITLE
Fixed OSGI versions in a manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,17 +129,6 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <version>5.1.9</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${project.name}</Bundle-Name>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <Export-Package>
-                            org.glassfish.external.*
-                        </Export-Package>
-                    </instructions>
-                </configuration>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>


### PR DESCRIPTION
- Felix now does awesome job, so this is not needed any more
- .SNAPSHOT in exports caused issues when using the artifact in a development phase.